### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/bennystreettough/152d3214-0c82-4a84-8b56-56957d57eed9/36f59638-e22e-430f-8524-4c791a8c49ee/_apis/work/boardbadge/79908849-2eca-4f1e-baee-85c7cb015775)](https://dev.azure.com/bennystreettough/152d3214-0c82-4a84-8b56-56957d57eed9/_boards/board/t/36f59638-e22e-430f-8524-4c791a8c49ee/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#482](https://dev.azure.com/bennystreettough/152d3214-0c82-4a84-8b56-56957d57eed9/_workitems/edit/482). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.